### PR TITLE
Implement support for ReadWriteOnce access mode

### DIFF
--- a/charts/woodpecker-agent/values.yaml
+++ b/charts/woodpecker-agent/values.yaml
@@ -13,7 +13,7 @@ env:
   WOODPECKER_BACKEND_K8S_NAMESPACE: woodpecker
   WOODPECKER_BACKEND_K8S_STORAGE_CLASS: ""
   WOODPECKER_BACKEND_K8S_VOLUME_SIZE: 10G
-  WOODPECKER_BACKEND_K8S_STORAGE_RWO: false
+  WOODPECKER_BACKEND_K8S_STORAGE_RWX: true
 
 # Docker-in-Docker is normally not needed as Woodpecker natively supports Kubernetes
 dind:

--- a/charts/woodpecker-agent/values.yaml
+++ b/charts/woodpecker-agent/values.yaml
@@ -13,6 +13,7 @@ env:
   WOODPECKER_BACKEND_K8S_NAMESPACE: woodpecker
   WOODPECKER_BACKEND_K8S_STORAGE_CLASS: ""
   WOODPECKER_BACKEND_K8S_VOLUME_SIZE: 10G
+  WOODPECKER_BACKEND_K8S_STORAGE_RWO: false
 
 # Docker-in-Docker is normally not needed as Woodpecker natively supports Kubernetes
 dind:

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -128,4 +128,10 @@ var flags = []cli.Flag{
 		Usage:   "backend k8s storage class",
 		Value:   "",
 	},
+	&cli.BoolFlag{
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_STORAGE_RWO"},
+		Name:    "backend-k8s-storage-rwo",
+		Usage:   "backend k8s storage access mode, should ReadWriteOnce be used?",
+		Value:   false,
+	},
 }

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -130,8 +130,8 @@ var flags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		EnvVars: []string{"WOODPECKER_BACKEND_K8S_STORAGE_RWO"},
-		Name:    "backend-k8s-storage-rwo",
-		Usage:   "backend k8s storage access mode, should ReadWriteOnce be used?",
-		Value:   false,
+		Name:    "backend-k8s-storage-rwm",
+		Usage:   "backend k8s storage access mode, should ReadWriteMany instead of ReadWriteOnce be used? (default: true)",
+		Value:   true,
 	},
 }

--- a/cmd/agent/flags.go
+++ b/cmd/agent/flags.go
@@ -129,9 +129,9 @@ var flags = []cli.Flag{
 		Value:   "",
 	},
 	&cli.BoolFlag{
-		EnvVars: []string{"WOODPECKER_BACKEND_K8S_STORAGE_RWO"},
-		Name:    "backend-k8s-storage-rwm",
-		Usage:   "backend k8s storage access mode, should ReadWriteMany instead of ReadWriteOnce be used? (default: true)",
+		EnvVars: []string{"WOODPECKER_BACKEND_K8S_STORAGE_RWX"},
+		Name:    "backend-k8s-storage-rwx",
+		Usage:   "backend k8s storage access mode, should ReadWriteMany (RWX) instead of ReadWriteOnce (RWO) be used? (default: true)",
 		Value:   true,
 	},
 }

--- a/pipeline/backend/backend.go
+++ b/pipeline/backend/backend.go
@@ -18,7 +18,7 @@ func Init(c *cli.Context) {
 		docker.New(),
 		local.New(),
 		ssh.New(),
-		kubernetes.New(c.String("backend-k8s-namespace"), c.String("backend-k8s-storage-class"), c.String("backend-k8s-volume-size")),
+		kubernetes.New(c.String("backend-k8s-namespace"), c.String("backend-k8s-storage-class"), c.String("backend-k8s-volume-size"), c.Bool("backend-k8s-storage-rwo")),
 	}
 
 	engines = make(map[string]types.Engine)

--- a/pipeline/backend/backend.go
+++ b/pipeline/backend/backend.go
@@ -18,7 +18,7 @@ func Init(c *cli.Context) {
 		docker.New(),
 		local.New(),
 		ssh.New(),
-		kubernetes.New(c.String("backend-k8s-namespace"), c.String("backend-k8s-storage-class"), c.String("backend-k8s-volume-size"), c.Bool("backend-k8s-storage-rwo")),
+		kubernetes.New(c.String("backend-k8s-namespace"), c.String("backend-k8s-storage-class"), c.String("backend-k8s-volume-size"), c.Bool("backend-k8s-storage-rwm")),
 	}
 
 	engines = make(map[string]types.Engine)

--- a/pipeline/backend/backend.go
+++ b/pipeline/backend/backend.go
@@ -18,7 +18,7 @@ func Init(c *cli.Context) {
 		docker.New(),
 		local.New(),
 		ssh.New(),
-		kubernetes.New(c.String("backend-k8s-namespace"), c.String("backend-k8s-storage-class"), c.String("backend-k8s-volume-size"), c.Bool("backend-k8s-storage-rwm")),
+		kubernetes.New(c.String("backend-k8s-namespace"), c.String("backend-k8s-storage-class"), c.String("backend-k8s-volume-size"), c.Bool("backend-k8s-storage-rwx")),
 	}
 
 	engines = make(map[string]types.Engine)

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -29,18 +29,18 @@ type kube struct {
 	namespace    string
 	storageClass string
 	volumeSize   string
-	rwo          bool
+	storageRwm          bool
 	client       kubernetes.Interface
 }
 
 // New returns a new Kubernetes Engine.
-func New(namespace, storageClass, volumeSize string, rwo bool) types.Engine {
+func New(namespace, storageClass, volumeSize string, storageRwm bool) types.Engine {
 	return &kube{
 		logs:         new(bytes.Buffer),
 		namespace:    namespace,
 		storageClass: storageClass,
 		volumeSize:   volumeSize,
-		rwo:          rwo,
+		storageRwm:          storageRwm,
 	}
 }
 
@@ -76,7 +76,7 @@ func (e *kube) Setup(ctx context.Context, conf *types.Config) error {
 	e.logs.WriteString("Setting up Kubernetes primitives\n")
 
 	for _, vol := range conf.Volumes {
-		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.rwo)
+		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.storageRwm)
 		_, err := e.client.CoreV1().PersistentVolumeClaims(e.namespace).Create(ctx, pvc, metav1.CreateOptions{})
 		if err != nil {
 			return err
@@ -279,7 +279,7 @@ func (e *kube) Destroy(ctx context.Context, conf *types.Config) error {
 	}
 
 	for _, vol := range conf.Volumes {
-		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.rwo)
+		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.storageRwm)
 		err := e.client.CoreV1().PersistentVolumeClaims(e.namespace).Delete(ctx, pvc.Name, deleteOpts)
 		if err != nil {
 			return err

--- a/pipeline/backend/kubernetes/kubernetes.go
+++ b/pipeline/backend/kubernetes/kubernetes.go
@@ -29,18 +29,18 @@ type kube struct {
 	namespace    string
 	storageClass string
 	volumeSize   string
-	storageRwm          bool
+	storageRwx   bool
 	client       kubernetes.Interface
 }
 
 // New returns a new Kubernetes Engine.
-func New(namespace, storageClass, volumeSize string, storageRwm bool) types.Engine {
+func New(namespace, storageClass, volumeSize string, storageRwx bool) types.Engine {
 	return &kube{
 		logs:         new(bytes.Buffer),
 		namespace:    namespace,
 		storageClass: storageClass,
 		volumeSize:   volumeSize,
-		storageRwm:          storageRwm,
+		storageRwx:   storageRwx,
 	}
 }
 
@@ -76,7 +76,7 @@ func (e *kube) Setup(ctx context.Context, conf *types.Config) error {
 	e.logs.WriteString("Setting up Kubernetes primitives\n")
 
 	for _, vol := range conf.Volumes {
-		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.storageRwm)
+		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.storageRwx)
 		_, err := e.client.CoreV1().PersistentVolumeClaims(e.namespace).Create(ctx, pvc, metav1.CreateOptions{})
 		if err != nil {
 			return err
@@ -279,7 +279,7 @@ func (e *kube) Destroy(ctx context.Context, conf *types.Config) error {
 	}
 
 	for _, vol := range conf.Volumes {
-		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.storageRwm)
+		pvc := PersistentVolumeClaim(e.namespace, vol.Name, e.storageClass, e.volumeSize, e.storageRwx)
 		err := e.client.CoreV1().PersistentVolumeClaims(e.namespace).Delete(ctx, pvc.Name, deleteOpts)
 		if err != nil {
 			return err

--- a/pipeline/backend/kubernetes/volume.go
+++ b/pipeline/backend/kubernetes/volume.go
@@ -8,10 +8,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PersistentVolumeClaim(namespace, name, storageClass, size string) *v1.PersistentVolumeClaim {
+func PersistentVolumeClaim(namespace, name, storageClass, size string, rwo bool) *v1.PersistentVolumeClaim {
 	_storageClass := &storageClass
 	if storageClass == "" {
 		_storageClass = nil
+	}
+
+	var accessMode v1.PersistentVolumeAccessMode
+
+	if rwo {
+		accessMode = v1.ReadWriteOnce
+	} else {
+		accessMode = v1.ReadWriteMany
 	}
 
 	return &v1.PersistentVolumeClaim{
@@ -20,7 +28,7 @@ func PersistentVolumeClaim(namespace, name, storageClass, size string) *v1.Persi
 			Namespace: namespace,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			AccessModes:      []v1.PersistentVolumeAccessMode{accessMode},
 			StorageClassName: _storageClass,
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{

--- a/pipeline/backend/kubernetes/volume.go
+++ b/pipeline/backend/kubernetes/volume.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PersistentVolumeClaim(namespace, name, storageClass, size string, storageRwm bool) *v1.PersistentVolumeClaim {
+func PersistentVolumeClaim(namespace, name, storageClass, size string, storageRwx bool) *v1.PersistentVolumeClaim {
 	_storageClass := &storageClass
 	if storageClass == "" {
 		_storageClass = nil
@@ -16,7 +16,7 @@ func PersistentVolumeClaim(namespace, name, storageClass, size string, storageRw
 
 	var accessMode v1.PersistentVolumeAccessMode
 
-	if storageRwm {
+	if storageRwx {
 		accessMode = v1.ReadWriteMany
 	} else {
 		accessMode = v1.ReadWriteOnce

--- a/pipeline/backend/kubernetes/volume.go
+++ b/pipeline/backend/kubernetes/volume.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PersistentVolumeClaim(namespace, name, storageClass, size string, rwo bool) *v1.PersistentVolumeClaim {
+func PersistentVolumeClaim(namespace, name, storageClass, size string, storageRwm bool) *v1.PersistentVolumeClaim {
 	_storageClass := &storageClass
 	if storageClass == "" {
 		_storageClass = nil
@@ -16,10 +16,10 @@ func PersistentVolumeClaim(namespace, name, storageClass, size string, rwo bool)
 
 	var accessMode v1.PersistentVolumeAccessMode
 
-	if rwo {
-		accessMode = v1.ReadWriteOnce
-	} else {
+	if storageRwm {
 		accessMode = v1.ReadWriteMany
+	} else {
+		accessMode = v1.ReadWriteOnce
 	}
 
 	return &v1.PersistentVolumeClaim{

--- a/pipeline/backend/kubernetes/volume_test.go
+++ b/pipeline/backend/kubernetes/volume_test.go
@@ -50,12 +50,12 @@ func TestPersistentVolumeClaim(t *testing.T) {
 	  "status": {}
 	}`
 
-	pvc := PersistentVolumeClaim("someNamespace", "someName", "local-storage", "1Gi", false)
+	pvc := PersistentVolumeClaim("someNamespace", "someName", "local-storage", "1Gi", true)
 	j, err := json.Marshal(pvc)
 	assert.Nil(t, err)
 	assert.JSONEq(t, expected_rwx, string(j))
 
-	pvc = PersistentVolumeClaim("someNamespace", "someName", "local-storage", "1Gi", true)
+	pvc = PersistentVolumeClaim("someNamespace", "someName", "local-storage", "1Gi", false)
 	j, err = json.Marshal(pvc)
 	assert.Nil(t, err)
 	assert.JSONEq(t, expected_rwo, string(j))

--- a/pipeline/backend/kubernetes/volume_test.go
+++ b/pipeline/backend/kubernetes/volume_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPersistentVolumeClaim(t *testing.T) {
-	expected := `
+	expected_rwx := `
 	{
 	  "metadata": {
 	    "name": "someName",
@@ -29,8 +29,34 @@ func TestPersistentVolumeClaim(t *testing.T) {
 	  "status": {}
 	}`
 
-	pvc := PersistentVolumeClaim("someNamespace", "someName", "local-storage", "1Gi")
+	expected_rwo := `
+	{
+	  "metadata": {
+	    "name": "someName",
+	    "namespace": "someNamespace",
+	    "creationTimestamp": null
+	  },
+	  "spec": {
+	    "accessModes": [
+	      "ReadWriteOnce"
+	    ],
+	    "resources": {
+	      "requests": {
+	        "storage": "1Gi"
+	      }
+	    },
+	    "storageClassName": "local-storage"
+	  },
+	  "status": {}
+	}`
+
+	pvc := PersistentVolumeClaim("someNamespace", "someName", "local-storage", "1Gi", false)
 	j, err := json.Marshal(pvc)
 	assert.Nil(t, err)
-	assert.JSONEq(t, expected, string(j))
+	assert.JSONEq(t, expected_rwx, string(j))
+
+	pvc = PersistentVolumeClaim("someNamespace", "someName", "local-storage", "1Gi", true)
+	j, err = json.Marshal(pvc)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected_rwo, string(j))
 }


### PR DESCRIPTION
Allow users to configure the usage of [ReadWriteOnce](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) (RWO) access mode.  
This is to simplify the setup needed for woodpecker-agent in k8s environments where ReadWriteMany (RWX) is overkill, and the trade-offs are ok. I.e. All steps are ok to force to run on same node.  
The default is still RWX and RWO is enabled with the `WOODPECKER_BACKEND_K8S_STORAGE_RWO=true` flag.

Ready-built container is available as [rynoxx/woodpecker-agent:k8s-rwo](https://hub.docker.com/r/rynoxx/woodpecker-agent).
I've tested in my own environment and it works fine for me.

